### PR TITLE
Lazy queries

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -12,7 +12,7 @@ targets = [
 ]
 
 [bans]
-multiple-versions = "deny"
+multiple-versions = "allow"
 wildcards         = "deny"
 
 deny = [

--- a/.deny.toml
+++ b/.deny.toml
@@ -12,7 +12,7 @@ targets = [
 ]
 
 [bans]
-multiple-versions = "allow"
+multiple-versions = "deny"
 wildcards         = "deny"
 
 deny = [
@@ -24,6 +24,7 @@ deny = [
   { crate = "windows", reason = "bloated and unnecessary", use-instead = "ideally inline bindings, practically, windows-sys" },
 ]
 skip = [
+  { crate = "heck@0.4.1", reason = "ouroboros uses this old version" },
   { crate = "hashbrown@0.14.5", reason = "gix uses this old version" },
   { crate = "core-foundation@0.9.4", reason = "reqwest -> system-configuration uses this old version" },
   { crate = "getrandom@0.2.15", reason = "ring uses this old version" },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,7 +153,7 @@ version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -214,6 +220,7 @@ dependencies = [
  "env_logger",
  "itertools",
  "log",
+ "ouroboros",
  "proptest",
  "regex",
  "rusqlite",
@@ -334,6 +341,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -451,6 +464,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +524,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -676,6 +726,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +802,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ diff                = "0.1.13"
 env_logger          = "0.11.3"
 itertools           = "0.14.0"
 log                 = "0.4.20"
+ouroboros           = "0.18.5"
 regex               = "1.11.1"
 rusqlite            = { version = "0.35.0", features = [ "bundled" ] }
 size                = "0.5.0"

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -282,7 +282,7 @@ fn write_packages_diffln(
 ) -> Result<usize, fmt::Error> {
   let mut paths = HashMap::<String, Diff<Vec<Version>>>::new();
 
-  // collect the names of old and new system packages
+  // Collect the names of old and new paths.
   let system_derivations_old: HashSet<String> = system_paths_old
     .filter_map(|path| {
       match path.parse_name_and_version() {

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -141,24 +141,30 @@ pub fn write_paths_diffln(
 ) -> Result<usize> {
   let connection = store::connect()?;
 
-  let paths_old = connection.query_dependents(path_old).with_context(|| {
-    format!(
-      "failed to query dependencies of path '{path}'",
-      path = path_old.display()
-    )
-  })?;
+  let paths_old: Vec<_> = connection
+    .query_dependents(path_old)
+    .with_context(|| {
+      format!(
+        "failed to query dependencies of path '{path}'",
+        path = path_old.display()
+      )
+    })?
+    .collect();
 
   log::info!(
     "found {count} packages in old closure",
     count = paths_old.len(),
   );
 
-  let paths_new = connection.query_dependents(path_new).with_context(|| {
-    format!(
-      "failed to query dependencies of path '{path}'",
-      path = path_new.display()
-    )
-  })?;
+  let paths_new: Vec<_> = connection
+    .query_dependents(path_new)
+    .with_context(|| {
+      format!(
+        "failed to query dependencies of path '{path}'",
+        path = path_new.display()
+      )
+    })?
+    .collect();
 
   let system_pkgs_old: Vec<_> = connection
     .query_packages(path_old)

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -107,8 +107,8 @@ enum PkgSelectionStatus {
 impl PkgSelectionStatus {
   fn from_pkgs_name(
     name: &str,
-    before: &HashSet<&str>,
-    after: &HashSet<&str>,
+    before: &HashSet<String>,
+    after: &HashSet<String>,
   ) -> Self {
     match (before.contains(name), after.contains(name)) {
       (true, true) => Self::Selected,
@@ -141,7 +141,7 @@ pub fn write_paths_diffln(
 ) -> Result<usize> {
   let connection = store::connect()?;
 
-  let paths_old: Vec<_> = connection
+  let paths_old = connection
     .query_dependents(path_old)
     .with_context(|| {
       format!(
@@ -149,15 +149,14 @@ pub fn write_paths_diffln(
         path = path_old.display()
       )
     })?
-    .map(|(_, path)| path)
-    .collect();
+    .map(|(_, path)| path);
 
   log::info!(
-    "found {count} packages in old closure",
-    count = paths_old.len(),
+    "found {count}+ packages in old closure",
+    count = paths_old.size_hint().0,
   );
 
-  let paths_new: Vec<_> = connection
+  let paths_new = connection
     .query_dependents(path_new)
     .with_context(|| {
       format!(
@@ -165,10 +164,9 @@ pub fn write_paths_diffln(
         path = path_new.display()
       )
     })?
-    .map(|(_, path)| path)
-    .collect();
+    .map(|(_, path)| path);
 
-  let system_pkgs_old: Vec<_> = connection
+  let system_pkgs_old = connection
     .query_packages(path_old)
     .with_context(|| {
       format!(
@@ -176,10 +174,9 @@ pub fn write_paths_diffln(
         path = path_old.display()
       )
     })?
-    .map(|(_, path)| path)
-    .collect();
+    .map(|(_, path)| path);
 
-  let system_pkgs_new: Vec<_> = connection
+  let system_pkgs_new = connection
     .query_packages(path_new)
     .with_context(|| {
       format!(
@@ -187,12 +184,11 @@ pub fn write_paths_diffln(
         path = path_old.display()
       )
     })?
-    .map(|(_, path)| path)
-    .collect();
+    .map(|(_, path)| path);
 
   log::info!(
-    "found {count} packages in new closure",
-    count = paths_new.len(),
+    "found {count}+ packages in new closure",
+    count = paths_new.size_hint().0,
   );
 
   writeln!(
@@ -212,10 +208,10 @@ pub fn write_paths_diffln(
 
   Ok(write_packages_diffln(
     writer,
-    paths_old.iter(),
-    paths_new.iter(),
-    system_pkgs_old.iter(),
-    system_pkgs_new.iter(),
+    paths_old,
+    paths_new,
+    system_pkgs_old,
+    system_pkgs_new,
   )?)
 }
 
@@ -274,19 +270,18 @@ fn deduplicate_versions(versions: &mut Vec<Version>) {
 #[expect(clippy::cognitive_complexity, clippy::too_many_lines)]
 fn write_packages_diffln<'a>(
   writer: &mut impl fmt::Write,
-  paths_old: impl Iterator<Item = &'a StorePath>,
-  paths_new: impl Iterator<Item = &'a StorePath>,
-  system_paths_old: impl Iterator<Item = &'a StorePath>,
-  system_paths_new: impl Iterator<Item = &'a StorePath>,
+  paths_old: impl Iterator<Item = StorePath>,
+  paths_new: impl Iterator<Item = StorePath>,
+  system_paths_old: impl Iterator<Item = StorePath>,
+  system_paths_new: impl Iterator<Item = StorePath>,
 ) -> Result<usize, fmt::Error> {
-  let mut paths = HashMap::<&str, Diff<Vec<Version>>>::new();
+  let mut paths = HashMap::<String, Diff<Vec<Version>>>::new();
 
   // collect the names of old and new system packages
-  let system_pkgs_old: HashSet<&str> = system_paths_old
-    .map(|path| path.parse_name_and_version())
-    .filter_map(|res| {
-      match res {
-        Ok((name, _)) => Some(name),
+  let system_pkgs_old: HashSet<String> = system_paths_old
+    .filter_map(|path| {
+      match path.parse_name_and_version() {
+        Ok((name, _)) => Some(name.into()),
         Err(error) => {
           log::warn!("error parsing old system path name and version: {error}");
           None
@@ -294,11 +289,10 @@ fn write_packages_diffln<'a>(
       }
     })
     .collect();
-  let system_pkgs_new: HashSet<&str> = system_paths_new
-    .map(|path| path.parse_name_and_version())
-    .filter_map(|res| {
-      match res {
-        Ok((name, _)) => Some(name),
+  let system_pkgs_new: HashSet<String> = system_paths_new
+    .filter_map(|path| {
+      match path.parse_name_and_version() {
+        Ok((name, _)) => Some(name.into()),
         Err(error) => {
           log::warn!("error parsing new system path name and version: {error}");
           None
@@ -314,7 +308,7 @@ fn write_packages_diffln<'a>(
         log::debug!("parsed version: {version:?}");
 
         paths
-          .entry(name)
+          .entry(name.into())
           .or_default()
           .old
           .push(version.unwrap_or_else(|| Version::from("<none>".to_owned())));
@@ -333,7 +327,7 @@ fn write_packages_diffln<'a>(
         log::debug!("parsed version: {version:?}");
 
         paths
-          .entry(name)
+          .entry(name.into())
           .or_default()
           .new
           .push(version.unwrap_or_else(|| Version::from("<none>".to_owned())));
@@ -390,7 +384,7 @@ fn write_packages_diffln<'a>(
       };
 
       let selection = PkgSelectionStatus::from_pkgs_name(
-        name,
+        &name,
         &system_pkgs_old,
         &system_pkgs_new,
       );
@@ -399,19 +393,19 @@ fn write_packages_diffln<'a>(
     })
     .collect::<Vec<_>>();
 
-  diffs.sort_by(|&(a_name, _, a_status, _), &(b_name, _, b_status, _)| {
-    a_status.cmp(&b_status).then_with(|| a_name.cmp(b_name))
+  diffs.sort_by(|(a_name, _, a_status, _), (b_name, _, b_status, _)| {
+    a_status.cmp(&b_status).then_with(|| a_name.cmp(&b_name))
   });
 
   let name_width = diffs
     .iter()
-    .map(|&(name, ..)| name.width())
+    .map(|(name, ..)| name.width())
     .max()
     .unwrap_or(0);
 
   let mut last_status = None::<DiffStatus>;
 
-  for &(name, ref versions, status, selection) in &diffs {
+  for &(ref name, ref versions, status, selection) in &diffs {
     use DiffStatus::{
       Added,
       Changed,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -108,9 +108,12 @@ enum DerivationSelectionStatus {
   NewlyUnselected,
 }
 
-
 impl DerivationSelectionStatus {
-  fn from_names(name: &str, old: &HashSet<&str>, new: &HashSet<&str>) -> Self {
+  fn from_names(
+    name: &str,
+    old: &HashSet<String>,
+    new: &HashSet<String>,
+  ) -> Self {
     match (old.contains(name), new.contains(name)) {
       (true, true) => Self::Selected,
       (true, false) => Self::NewlyUnselected,
@@ -187,7 +190,7 @@ pub fn write_paths_diffln(
       )
     })?
     .map(|(_, path)| path);
-  
+
   log::info!(
     "found {count}+ packages in new closure",
     count = paths_new.size_hint().0,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -149,6 +149,7 @@ pub fn write_paths_diffln(
         path = path_old.display()
       )
     })?
+    .map(|(_, path)| path)
     .collect();
 
   log::info!(
@@ -164,6 +165,7 @@ pub fn write_paths_diffln(
         path = path_new.display()
       )
     })?
+    .map(|(_, path)| path)
     .collect();
 
   let system_pkgs_old: Vec<_> = connection
@@ -174,7 +176,9 @@ pub fn write_paths_diffln(
         path = path_old.display()
       )
     })?
+    .map(|(_, path)| path)
     .collect();
+
   let system_pkgs_new: Vec<_> = connection
     .query_packages(path_new)
     .with_context(|| {
@@ -183,14 +187,13 @@ pub fn write_paths_diffln(
         path = path_old.display()
       )
     })?
+    .map(|(_, path)| path)
     .collect();
 
   log::info!(
     "found {count} packages in new closure",
     count = paths_new.len(),
   );
-
-  drop(connection);
 
   writeln!(
     writer,
@@ -210,10 +213,10 @@ pub fn write_paths_diffln(
   #[expect(clippy::pattern_type_mismatch)]
   Ok(write_packages_diffln(
     writer,
-    paths_old.iter().map(|(_, path)| path),
-    paths_new.iter().map(|(_, path)| path),
-    system_pkgs_old.iter().map(|(_, path)| path),
-    system_pkgs_new.iter().map(|(_, path)| path),
+    paths_old.iter(),
+    paths_new.iter(),
+    system_pkgs_old.iter(),
+    system_pkgs_new.iter(),
   )?)
 }
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -268,7 +268,7 @@ fn deduplicate_versions(versions: &mut Vec<Version>) {
 }
 
 #[expect(clippy::cognitive_complexity, clippy::too_many_lines)]
-fn write_packages_diffln<'a>(
+fn write_packages_diffln(
   writer: &mut impl fmt::Write,
   paths_old: impl Iterator<Item = StorePath>,
   paths_new: impl Iterator<Item = StorePath>,
@@ -393,10 +393,13 @@ fn write_packages_diffln<'a>(
     })
     .collect::<Vec<_>>();
 
-  diffs.sort_by(|(a_name, _, a_status, _), (b_name, _, b_status, _)| {
-    a_status.cmp(&b_status).then_with(|| a_name.cmp(&b_name))
-  });
+  diffs.sort_by(
+    |&(ref a_name, _, a_status, _), &(ref b_name, _, b_status, _)| {
+      a_status.cmp(&b_status).then_with(|| a_name.cmp(b_name))
+    },
+  );
 
+  #[expect(clippy::pattern_type_mismatch)]
   let name_width = diffs
     .iter()
     .map(|(name, ..)| name.width())

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -210,7 +210,6 @@ pub fn write_paths_diffln(
 
   writeln!(writer)?;
 
-  #[expect(clippy::pattern_type_mismatch)]
   Ok(write_packages_diffln(
     writer,
     paths_old.iter(),

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -160,20 +160,24 @@ pub fn write_paths_diffln(
     )
   })?;
 
-  let system_pkgs_old =
-    connection.query_packages(path_old).with_context(|| {
+  let system_pkgs_old: Vec<_> = connection
+    .query_packages(path_old)
+    .with_context(|| {
       format!(
         "failed to query system packages of path '{path}",
         path = path_old.display()
       )
-    })?;
-  let system_pkgs_new =
-    connection.query_packages(path_new).with_context(|| {
+    })?
+    .collect();
+  let system_pkgs_new: Vec<_> = connection
+    .query_packages(path_new)
+    .with_context(|| {
       format!(
         "failed to query system packages of path '{path}",
         path = path_old.display()
       )
-    })?;
+    })?
+    .collect();
 
   log::info!(
     "found {count} packages in new closure",

--- a/src/store.rs
+++ b/src/store.rs
@@ -206,9 +206,9 @@ fn path_to_canonical_string(path: &Path) -> Result<String> {
 }
 
 impl Connection {
-  /// executes a query that returns multiple rows and returns
+  /// Executes a query that returns multiple rows and returns
   /// an iterator over them where the `map` is used to map
-  /// the sql rows to `T`
+  /// the rows to `T`.
   pub fn execute_row_query_with_path<T, M>(
     &self,
     query: &str,

--- a/src/store.rs
+++ b/src/store.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 
 #[derive(Deref)]
-/// A wrapper around the internal rusqlite Connection
+/// A Nix database connection.
 pub struct Connection(rusqlite::Connection);
 
 type FilterOkFunc<T> = fn(Result<T, rusqlite::Error>) -> Option<T>;

--- a/src/store.rs
+++ b/src/store.rs
@@ -312,10 +312,10 @@ impl Connection {
     })
   }
 
-  /// returns all edges of the dependency graph
+  /// Returns all edges of the dependency graph.
   ///
-  /// you might want to build an adjacency list from the resulting
-  /// edges
+  /// You might want to build an adjacency list from the resulting
+  /// edges.
   #[expect(dead_code)]
   pub fn query_dependency_graph(
     &self,

--- a/src/store.rs
+++ b/src/store.rs
@@ -58,8 +58,8 @@ where
   inner: FilterMap<Peekable<MappedRows<'this, F>>, FilterOkFunc<T>>,
 }
 
-/// The iterator over the data resulting from an SQL query,
-/// where the rows are mapped to `T`
+/// The iterator over the data resulting from a SQL query,
+/// where the rows are mapped to `T`.
 ///
 /// We ignore all rows where the conversion fails,
 /// but take a look at the first row to make sure
@@ -68,7 +68,7 @@ where
 /// The idea is to only use very trivial
 /// conversions that will never fail
 /// if the query actually returns the correct number
-/// of rows
+/// of rows.
 pub struct QueryIterator<'conn, T, F>
 where
   T: 'static,

--- a/src/store.rs
+++ b/src/store.rs
@@ -48,13 +48,13 @@ where
 {
   /// statement prepared by the sql connection
   stmt:  CachedStatement<'conn>,
-  #[borrows(mut stmt)]
-  #[not_covariant]
   /// The actual iterator we generate from the query iterator
   ///
   /// note that the concrete datatype is rather complicated,
   /// since we wan't to avoid a box, since we currently only have a single
   /// way to deal wihh queries that return multiple rows
+  #[borrows(mut stmt)]
+  #[not_covariant]
   inner: FilterMap<Peekable<MappedRows<'this, F>>, FilterOkFunc<T>>,
 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -83,7 +83,7 @@ where
 {
   /// May fail if the query itself fails or
   /// if the first row of the query result can not
-  /// be mapped to `T`
+  /// be mapped to `T`.
   pub fn try_new<P: rusqlite::Params>(
     stmt: CachedStatement<'conn>,
     params: P,

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::mem_forget)]
+
 use std::{
   iter::{
     FilterMap,
@@ -70,14 +72,15 @@ where
 
       match inner_iter {
         Ok(mut iter) => {
-          if let Some(Err(e)) = iter.peek() {
-            return Err(anyhow!("First row conversion failed: {e:?}"));
+          #[expect(clippy::pattern_type_mismatch)]
+          if let Some(Err(err)) = iter.peek() {
+            return Err(anyhow!("First row conversion failed: {err:?}"));
           }
           let iter_filtered = iter.filter_map(Result::ok as FilterOkFunc<T>);
 
           Ok(iter_filtered)
         },
-        Err(e) => Err(e),
+        Err(err) => Err(err),
       }
     });
     cell_res.map(|cell| Self { cell })

--- a/src/store.rs
+++ b/src/store.rs
@@ -124,8 +124,6 @@ where
   F: Fn(&rusqlite::Row) -> rusqlite::Result<T>,
 {
   type Item = T;
-  /// Simple wrapper around the underlying iterator
-  /// contained in the cell
   fn next(&mut self) -> Option<Self::Item> {
     self.cell.with_inner_mut(|inner| inner.next())
   }

--- a/src/store.rs
+++ b/src/store.rs
@@ -36,7 +36,7 @@ pub struct Connection(rusqlite::Connection);
 type FilterOkFunc<T> = fn(Result<T, rusqlite::Error>) -> Option<T>;
 
 #[self_referencing]
-/// Contains the sql statement and the query resulting from it
+/// Contains the SQL statement and the query resulting from it.
 ///
 /// This is necessary since the statement is only created during
 /// the query method on the Connection. The query however contains

--- a/src/store.rs
+++ b/src/store.rs
@@ -6,7 +6,6 @@ use std::{
     Iterator,
     Peekable,
   },
-  marker::PhantomData,
   path::Path,
 };
 
@@ -40,11 +39,10 @@ where
   T: 'static,
   F: Fn(&rusqlite::Row) -> rusqlite::Result<T>,
 {
-  stmt:   CachedStatement<'conn>,
-  with_m: PhantomData<F>,
+  stmt:  CachedStatement<'conn>,
   #[borrows(mut stmt)]
   #[not_covariant]
-  inner:  FilterMap<Peekable<MappedRows<'this, F>>, FilterOkFunc<T>>,
+  inner: FilterMap<Peekable<MappedRows<'this, F>>, FilterOkFunc<T>>,
 }
 
 pub struct QueryIterator<'conn, T, F>
@@ -64,7 +62,7 @@ where
     params: P,
     map: F,
   ) -> Result<Self> {
-    let cell_res = QueryIteratorCell::try_new(stmt, PhantomData, |stmt| {
+    let cell_res = QueryIteratorCell::try_new(stmt, |stmt| {
       let inner_iter = stmt
         .query_map(params, map)
         .map(Iterator::peekable)


### PR DESCRIPTION
This PR allows directly getting an iterator over the results of our queries on the store
instead of waiting until the whole query has finished. This allows us to directly
start processing while the query is running.