### PR TITLE
feat: add `--color {auto,never,always}` cli flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,15 @@ struct Cli {
 
   #[command(flatten)]
   verbose: clap_verbosity_flag::Verbosity,
+
+  /// Controls when to use color.
+  #[arg(
+      long,
+      default_value_t = clap::ColorChoice::Auto,
+      value_name = "WHEN",
+      global = true,
+  )]
+  color: clap::ColorChoice,
 }
 
 fn real_main() -> Result<()> {
@@ -41,9 +50,14 @@ fn real_main() -> Result<()> {
     old_path,
     new_path,
     verbose,
+    color,
   } = Cli::parse();
 
-  yansi::whenever(yansi::Condition::TTY_AND_COLOR);
+  yansi::whenever(match color {
+    clap::ColorChoice::Auto => yansi::Condition::TTY_AND_COLOR,
+    clap::ColorChoice::Always => yansi::Condition::ALWAYS,
+    clap::ColorChoice::Never => yansi::Condition::NEVER,
+  });
 
   env_logger::Builder::new()
     .filter_level(verbose.log_level_filter())


### PR DESCRIPTION
fixes part of #42 

Only adds a `--color` flag, doesn't change the env var mess.

I could also use the https://docs.rs/clap-color-flag micro-dependency, which does the same thing (and adds a small integration for the `colorchoice` global bool). Although the crate is obviously done and is maintained by steve klabnik, it points to the non-existant repo https://github.com/clap-rs/clap-color-flag which is a bit sketch.