### PR TITLE
expose detached closure snapshot diffing as a library API

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -44,6 +44,11 @@ use yansi::{
 use crate::{
   StorePath,
   Version,
+  snapshot::{
+    SnapshotDiffReport,
+    diff_snapshots,
+    gather_snapshot,
+  },
   store::{
     self,
     StoreBackend,
@@ -186,27 +191,15 @@ impl DerivationSelectionStatus {
   }
 }
 
-/// Writes a package diff between two paths to the provided writer.
+/// Computes a package diff report between two paths.
 ///
-/// This function queries the dependencies and system derivations of the
-/// provided paths, and then generates and renders a diff between them.
-///
-/// # Returns
-///
-/// Returns the number of package diffs written.
-///
-/// # Errors
-///
-/// Returns an error if:
-/// - Failed to connect to the store
-/// - Failed to query dependencies or system derivations
-/// - Failed to write to the output
-pub fn write_package_diff(
-  writer: &mut impl fmt::Write,
+/// This gathers detached closure snapshots from the configured backend and
+/// then reuses `diff_snapshots(...)` for the semantic package diffing step.
+pub fn package_diff_report(
   path_old: &Path,
   path_new: &Path,
   force_correctness: bool,
-) -> Result<usize> {
+) -> Result<SnapshotDiffReport> {
   tracing::debug!(
     old_path = %path_old.display(),
     new_path = %path_new.display(),
@@ -216,57 +209,44 @@ pub fn write_package_diff(
   let mut connection = create_backend(force_correctness);
   connection.connect()?;
 
-  tracing::debug!("querying dependencies for old path");
-  // Query dependencies for old path
-  let paths_old = connection.query_dependents(path_old).with_context(|| {
-    format!("failed to query dependencies of '{}'", path_old.display())
-  })?;
-
-  tracing::debug!("querying dependencies for new path");
-  // Query dependencies for new path
-  let paths_new = connection.query_dependents(path_new).with_context(|| {
-    format!("failed to query dependencies of '{}'", path_new.display())
-  })?;
-
-  tracing::debug!("querying system derivations for old path");
-  // Query system derivations for old path
-  let system_derivations_old = connection
-    .query_system_derivations(path_old)
-    .with_context(|| {
-      format!(
-        "failed to query system derivations of '{}'",
-        path_old.display()
-      )
-    })?;
-
-  tracing::debug!("querying system derivations for new path");
-  // Query system derivations for new path
-  let system_derivations_new = connection
-    .query_system_derivations(path_new)
-    .with_context(|| {
-      format!(
-        "failed to query system derivations of '{}'",
-        path_new.display()
-      )
-    })?;
-
-  writeln!(writer)?;
-
-  // Generate and write the diff
-  tracing::debug!("generating and writing package diff");
-  let count = write_packages_diff(
-    writer,
-    paths_old,
-    paths_new,
-    system_derivations_old,
-    system_derivations_new,
-  )
-  .map_err(Error::from);
-
-  tracing::info!(diff_count = ?count.as_ref().ok(), "package diff complete");
+  let report = (|| {
+    let old = gather_snapshot(path_old, &connection)
+      .with_context(|| format!("failed to gather snapshot for '{}'", path_old.display()))?;
+    let new = gather_snapshot(path_new, &connection)
+      .with_context(|| format!("failed to gather snapshot for '{}'", path_new.display()))?;
+    diff_snapshots(&old, &new)
+  })();
 
   connection.close()?;
+  report
+}
 
+/// Writes a package diff between two paths to the provided writer.
+///
+/// This gathers detached closure snapshots from the configured backend and
+/// renders the resulting semantic package diff.
+///
+/// # Returns
+///
+/// Returns the number of package diffs written.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - Failed to connect to the store
+/// - Failed to gather snapshots
+/// - Failed to write to the output
+pub fn write_package_diff(
+  writer: &mut impl fmt::Write,
+  path_old: &Path,
+  path_new: &Path,
+  force_correctness: bool,
+) -> Result<usize> {
+  let report = package_diff_report(path_old, path_new, force_correctness)?;
+
+  writeln!(writer)?;
+  let count = render_diffs(writer, &report.diffs).map_err(Error::from);
+  tracing::info!(diff_count = ?count.as_ref().ok(), "package diff complete");
   count
 }
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -12,12 +12,13 @@ use serde::Serialize;
 use crate::{
   diff::{
     Diff,
-    add_selection_status,
-    collect_path_versions,
-    collect_system_names,
-    create_backend,
+    package_diff_report,
   },
-  generate_diffs_from_paths,
+  snapshot::{
+    SnapshotDiffReport,
+    diff_snapshots,
+    gather_snapshot,
+  },
   store::StoreBackend,
 };
 
@@ -26,9 +27,8 @@ pub fn display_diff(
   path_new: &PathBuf,
   force_correctness: bool,
 ) -> Result<()> {
-  let mut connection = create_backend(force_correctness);
-  connection.connect()?;
-  generate_diff(&mut std::io::stdout(), path_old, path_new, &connection)
+  let report = package_diff_report(path_old, path_new, force_correctness)?;
+  write_json_report(&mut std::io::stdout(), report)
 }
 
 fn generate_diff<'a>(
@@ -37,58 +37,20 @@ fn generate_diff<'a>(
   path_new: &PathBuf,
   backend: &impl StoreBackend<'a>,
 ) -> Result<()> {
-  // Query dependencies for old path
-  let paths_old = backend.query_dependents(path_old).with_context(|| {
-    format!("failed to query dependencies of '{}'", path_old.display())
-  })?;
+  let old = gather_snapshot(path_old, backend)
+    .with_context(|| format!("failed to gather snapshot for '{}'", path_old.display()))?;
+  let new = gather_snapshot(path_new, backend)
+    .with_context(|| format!("failed to gather snapshot for '{}'", path_new.display()))?;
+  let report = diff_snapshots(&old, &new)?;
+  write_json_report(out, report)
+}
 
-  // Query dependencies for new path
-  let paths_new = backend.query_dependents(path_new).with_context(|| {
-    format!("failed to query dependencies of '{}'", path_new.display())
-  })?;
-
-  // Query system derivations for old path
-  let system_derivations_old = backend
-    .query_system_derivations(path_old)
-    .with_context(|| {
-      format!(
-        "failed to query system derivations of '{}'",
-        path_old.display()
-      )
-    })?;
-
-  // Query system derivations for new path
-  let system_derivations_new = backend
-    .query_system_derivations(path_new)
-    .with_context(|| {
-      format!(
-        "failed to query system derivations of '{}'",
-        path_new.display()
-      )
-    })?;
-
-  let paths_map = collect_path_versions(paths_old, paths_new);
-  let sys_old_set = collect_system_names(system_derivations_old, "old");
-  let sys_new_set = collect_system_names(system_derivations_new, "new");
-
-  let mut diffs = generate_diffs_from_paths(paths_map);
-  // Make sure the diffs are always in the same order so
-  // our tests testing against the output don't fail nondeterministically.
-  for diff in &mut diffs {
-    diff.new.sort();
-    diff.old.sort();
-  }
-  diffs.sort();
-  add_selection_status(&mut diffs, &sys_old_set, &sys_new_set);
-  let size_old = backend.query_closure_size(path_old)?.bytes();
-  let size_new = backend.query_closure_size(path_new)?.bytes();
-
-  serde_json::to_writer(out, &JsonReport {
-    diffs,
-    size_old,
-    size_new,
-  })
-  .context("Failed to write json output.")
+fn write_json_report(
+  out: &mut dyn Write,
+  report: SnapshotDiffReport,
+) -> Result<()> {
+  serde_json::to_writer(out, &JsonReport::from(report))
+    .context("Failed to write json output.")
 }
 
 #[derive(Serialize)]
@@ -99,6 +61,16 @@ pub struct JsonReport {
   size_old: i64,
   /// new closure size (in bytes)
   size_new: i64,
+}
+
+impl From<SnapshotDiffReport> for JsonReport {
+  fn from(report: SnapshotDiffReport) -> Self {
+    Self {
+      diffs: report.diffs,
+      size_old: report.size_old,
+      size_new: report.size_new,
+    }
+  }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,13 @@ pub use diff::{
   write_size_diff,
 };
 
+pub mod snapshot;
+pub use snapshot::{
+  ClosureSnapshot,
+  SnapshotDiffReport,
+  diff_snapshots,
+};
+
 pub mod store;
 
 pub mod version;
@@ -37,6 +44,7 @@ use version::Version;
 ///
 /// Can be created using `StorePath::try_from(path_buf)`.
 #[derive(Deref, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "json", derive(serde::Serialize))]
 pub struct StorePath(PathBuf);
 
 impl TryFrom<PathBuf> for StorePath {

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,0 +1,301 @@
+use std::{
+  collections::HashSet,
+  path::Path,
+};
+
+use eyre::{Result, WrapErr as _, bail};
+
+use crate::{
+  StorePath,
+  diff::{
+    Diff, add_selection_status, collect_path_versions, collect_system_names,
+  },
+  generate_diffs_from_paths,
+  store::StoreBackend,
+};
+
+/// A detached, normalized closure snapshot.
+///
+/// This value is intentionally independent from any live store backend so
+/// callers can gather closure facts remotely and later diff them locally.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(serde::Serialize))]
+pub struct ClosureSnapshot {
+  /// Root path the snapshot was gathered from.
+  pub root_path: StorePath,
+  /// Total transitive closure size in bytes.
+  pub closure_size_bytes: i64,
+  /// All store paths in the transitive closure of the root.
+  pub closure_paths: Vec<StorePath>,
+  /// Directly selected system package paths from `<root>/sw`.
+  pub selected_paths: Vec<StorePath>,
+}
+
+/// A package diff report produced from two detached closure snapshots.
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(serde::Serialize))]
+pub struct SnapshotDiffReport {
+  /// package changes
+  pub diffs: Vec<Diff>,
+  /// old closure size (in bytes)
+  pub size_old: i64,
+  /// new closure size (in bytes)
+  pub size_new: i64,
+}
+
+/// Computes a package diff report from two detached closure snapshots.
+///
+/// The function is pure over already-normalized snapshot data. It does not
+/// query a live Nix store and does not require the compared roots to exist on
+/// the local machine.
+pub fn diff_snapshots(
+  old: &ClosureSnapshot,
+  new: &ClosureSnapshot,
+) -> Result<SnapshotDiffReport> {
+  validate_snapshot(old)?;
+  validate_snapshot(new)?;
+
+  let paths_map = collect_path_versions(
+    old.closure_paths.iter().cloned(),
+    new.closure_paths.iter().cloned(),
+  );
+  let sys_old_set =
+    collect_system_names(old.selected_paths.iter().cloned(), "old snapshot");
+  let sys_new_set =
+    collect_system_names(new.selected_paths.iter().cloned(), "new snapshot");
+
+  let mut diffs = generate_diffs_from_paths(paths_map);
+  for diff in &mut diffs {
+    diff.new.sort();
+    diff.old.sort();
+  }
+  add_selection_status(&mut diffs, &sys_old_set, &sys_new_set);
+  diffs
+    .sort_by(|a, b| a.status.cmp(&b.status).then_with(|| a.name.cmp(&b.name)));
+
+  Ok(SnapshotDiffReport {
+    diffs,
+    size_old: old.closure_size_bytes,
+    size_new: new.closure_size_bytes,
+  })
+}
+
+pub(crate) fn gather_snapshot<'a>(
+  path: &Path,
+  backend: &impl StoreBackend<'a>,
+) -> Result<ClosureSnapshot> {
+  tracing::debug!(path = %path.display(), "gathering closure snapshot");
+  let root_path = match StorePath::try_from(path.to_path_buf()) {
+    Ok(path) => path,
+    Err(_) => {
+      let canonical = path.canonicalize().wrap_err_with(|| {
+        format!("failed to canonicalize path '{}'", path.display())
+      })?;
+      StorePath::try_from(canonical)?
+    },
+  };
+
+  tracing::trace!(path = %path.display(), "querying closure size for snapshot");
+  let closure_size_bytes = backend.query_closure_size(path)?.bytes();
+  tracing::trace!(path = %path.display(), "querying closure paths for snapshot");
+  let closure_paths = backend.query_dependents(path)?.collect::<Vec<_>>();
+  tracing::trace!(path = %path.display(), "querying selected system paths for snapshot");
+  let selected_paths = backend.query_system_derivations(path)?.collect::<Vec<_>>();
+
+  let snapshot = ClosureSnapshot {
+    root_path,
+    closure_size_bytes,
+    closure_paths,
+    selected_paths,
+  };
+  validate_snapshot(&snapshot)?;
+  tracing::debug!(
+    root_path = %snapshot.root_path.display(),
+    closure_paths = snapshot.closure_paths.len(),
+    selected_paths = snapshot.selected_paths.len(),
+    closure_size_bytes = snapshot.closure_size_bytes,
+    "gathered closure snapshot"
+  );
+  Ok(snapshot)
+}
+
+fn validate_snapshot(snapshot: &ClosureSnapshot) -> Result<()> {
+  let closure_paths = snapshot.closure_paths.iter().collect::<HashSet<_>>();
+
+  for selected_path in &snapshot.selected_paths {
+    if !closure_paths.contains(selected_path) {
+      bail!(
+        "selected path '{}' is not present in closure snapshot for '{}'",
+        selected_path.display(),
+        snapshot.root_path.display()
+      );
+    }
+  }
+
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use std::path::PathBuf;
+
+  use crate::{
+    diff::{Change, DerivationSelectionStatus, DiffStatus},
+    store::{
+      LazyDBConnection, StoreBackend,
+      test_utils::{self, fixtures},
+    },
+  };
+
+  use super::*;
+
+  fn store_path(hash: &str, suffix: &str) -> StorePath {
+    StorePath::try_from(PathBuf::from(format!(
+      "/tmp/dix-snapshot-tests/{hash}-{suffix}"
+    )))
+    .unwrap()
+  }
+
+  #[test]
+  fn diff_snapshots_reports_semantic_changes_from_detached_data() {
+    let old = ClosureSnapshot {
+      root_path: store_path(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "nixos-system-old",
+      ),
+      closure_size_bytes: 100,
+      closure_paths: vec![
+        store_path("11111111111111111111111111111111", "bash-5.2"),
+        store_path("22222222222222222222222222222222", "nano-8.0"),
+        store_path("33333333333333333333333333333333", "glibc-2.42"),
+      ],
+      selected_paths: vec![
+        store_path("11111111111111111111111111111111", "bash-5.2"),
+        store_path("22222222222222222222222222222222", "nano-8.0"),
+      ],
+    };
+
+    let new = ClosureSnapshot {
+      root_path: store_path(
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "nixos-system-new",
+      ),
+      closure_size_bytes: 120,
+      closure_paths: vec![
+        store_path("44444444444444444444444444444444", "bash-5.3"),
+        store_path("33333333333333333333333333333333", "glibc-2.42"),
+        store_path("55555555555555555555555555555555", "ripgrep-14.1"),
+      ],
+      selected_paths: vec![
+        store_path("44444444444444444444444444444444", "bash-5.3"),
+        store_path("55555555555555555555555555555555", "ripgrep-14.1"),
+      ],
+    };
+
+    let report = diff_snapshots(&old, &new).unwrap();
+
+    assert_eq!(report.size_old, 100);
+    assert_eq!(report.size_new, 120);
+    assert_eq!(report.diffs.len(), 3);
+
+    let bash = report
+      .diffs
+      .iter()
+      .find(|diff| diff.name == "bash")
+      .unwrap();
+    assert_eq!(bash.status, DiffStatus::Changed(Change::Upgraded));
+    assert_eq!(bash.selection, DerivationSelectionStatus::Selected);
+
+    let ripgrep = report
+      .diffs
+      .iter()
+      .find(|diff| diff.name == "ripgrep")
+      .unwrap();
+    assert_eq!(ripgrep.status, DiffStatus::Added);
+    assert_eq!(ripgrep.selection, DerivationSelectionStatus::NewlySelected);
+
+    let nano = report
+      .diffs
+      .iter()
+      .find(|diff| diff.name == "nano")
+      .unwrap();
+    assert_eq!(nano.status, DiffStatus::Removed);
+    assert_eq!(nano.selection, DerivationSelectionStatus::NewlyUnselected);
+  }
+
+  #[test]
+  fn diff_snapshots_rejects_selected_paths_outside_the_closure() {
+    let snapshot = ClosureSnapshot {
+      root_path: store_path(
+        "cccccccccccccccccccccccccccccccc",
+        "nixos-system-invalid",
+      ),
+      closure_size_bytes: 42,
+      closure_paths: vec![store_path(
+        "66666666666666666666666666666666",
+        "bash-5.3",
+      )],
+      selected_paths: vec![store_path(
+        "77777777777777777777777777777777",
+        "ripgrep-14.1",
+      )],
+    };
+
+    let err = diff_snapshots(&snapshot, &snapshot).unwrap_err();
+    assert!(
+      err.to_string().contains("selected path")
+        && err.to_string().contains("not present in closure snapshot")
+    );
+  }
+
+  #[test]
+  fn diff_snapshots_matches_fixture_queries_without_live_diff_queries() {
+    let db_builder = test_utils::create_system_test_db().unwrap();
+    let db_path = db_builder.db_path().to_string_lossy().to_string();
+    let mut db = LazyDBConnection::new(&db_path);
+    db.connect().unwrap();
+
+    let system_old =
+      db_builder.resolve_fixture_path(&fixtures::system_path("nixos-25.11"));
+    let system_new =
+      db_builder.resolve_fixture_path(&fixtures::system_path("nixos-25.12"));
+
+    let old = ClosureSnapshot {
+      root_path: StorePath::try_from(PathBuf::from(system_old.clone()))
+        .unwrap(),
+      closure_size_bytes: db.query_closure_size(&system_old).unwrap().bytes(),
+      closure_paths: db.query_dependents(&system_old).unwrap().collect(),
+      selected_paths: db
+        .query_system_derivations(&system_old)
+        .unwrap()
+        .collect(),
+    };
+
+    let new = ClosureSnapshot {
+      root_path: StorePath::try_from(PathBuf::from(system_new.clone()))
+        .unwrap(),
+      closure_size_bytes: db.query_closure_size(&system_new).unwrap().bytes(),
+      closure_paths: db.query_dependents(&system_new).unwrap().collect(),
+      selected_paths: db
+        .query_system_derivations(&system_new)
+        .unwrap()
+        .collect(),
+    };
+
+    let report = diff_snapshots(&old, &new).unwrap();
+
+    assert_eq!(report.size_old, 115001000);
+    assert_eq!(report.size_new, 115001000);
+    assert_eq!(report.diffs.len(), 1);
+    assert_eq!(report.diffs[0].name, "nixos");
+    assert_eq!(
+      report.diffs[0].status,
+      DiffStatus::Changed(Change::Upgraded)
+    );
+    assert_eq!(
+      report.diffs[0].selection,
+      DerivationSelectionStatus::Unselected
+    );
+    assert!(!report.diffs[0].has_common_versions);
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a minimal detached snapshot API to the `dix` library without changing the CLI surface.

### Added

- `snapshot::ClosureSnapshot`
- `snapshot::SnapshotDiffReport`
- `snapshot::diff_snapshots(old, new)`
- re-exports from the crate root:
  - `dix::ClosureSnapshot`
  - `dix::SnapshotDiffReport`
  - `dix::diff_snapshots(...)`

### Why

Today `dix` already has a clean separation between:

1. querying closure facts from a live store/backend
2. computing a semantic package/version diff from those facts

This PR exposes the second part directly so downstream Rust code can:

- gather closure facts remotely or from custom sources
- normalize them into detached snapshots
- reuse `dix`'s package diff algorithm locally

without requiring:

- both compared roots to exist locally
- new CLI commands
- new backend types in this first step

## API shape

A `ClosureSnapshot` carries the detached data that `dix`'s package diff needs:

- `root_path`
- `closure_size_bytes`
- `closure_paths`
- `selected_paths`

`diff_snapshots(...)` is pure over that detached data and returns a `SnapshotDiffReport`.

As a small convenience, `StorePath`, `ClosureSnapshot`, and `SnapshotDiffReport` also derive `Serialize` behind the existing `json` feature.

## Internal reuse in the existing flow

The new API is not left as a disconnected library surface.

The normal `dix` flow now reuses it internally:

- `write_package_diff(...)` gathers detached snapshots from the configured backend and then delegates the semantic diffing step to `diff_snapshots(...)`
- JSON output follows the same pattern

So the snapshot API becomes the shared semantic diff layer for both:

- existing store-backed CLI behavior
- future detached or remote/local library consumers

## Validation

The new tests cover:

- semantic package diffing from fully detached synthetic snapshots
- rejection of inconsistent snapshots when `selected_paths` are not part of the closure
- equivalence with existing fixture-backed query semantics by building snapshots from the test backend and diffing them without live diff queries

## Tests run locally

- `cargo test snapshot::tests --lib`
- `cargo test json::tests::test_basic_json_output_format --lib`
- `cargo test diff::tests::generate_diffs_from_paths_test --lib`

## Observed local test note

In this environment, full `cargo test` still hits an unrelated existing failure in `tests::test_path_to_canonical_string_invalid_unicode`. That failure is not part of this snapshot patch.

## Non-goals

This PR intentionally does **not** add:

- new CLI commands like `dix snapshot` or `dix diff-snapshots`
- remote-store support in the CLI
- a new snapshot backend abstraction

Those can come later if this library surface proves useful.
