### PR TITLE
diff: count version multiplicity instead of set-flattening

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -958,15 +958,24 @@ pub fn generate_diffs_from_paths<S: BuildHasher>(
     let old_counts = count_versions(old_versions);
     let new_counts = count_versions(new_versions);
 
-    let old_set: HashSet<Version> = old_counts.keys().cloned().collect();
-    let new_set: HashSet<Version> = new_counts.keys().cloned().collect();
-
-    let common_count = old_set.intersection(&new_set).count();
-
-    let unique_old: Vec<Version> =
-      old_set.difference(&new_set).cloned().collect();
-    let unique_new: Vec<Version> =
-      new_set.difference(&old_set).cloned().collect();
+    let mut common_count = 0usize;
+    let mut unique_old: Vec<Version> = Vec::new();
+    let mut unique_new: Vec<Version> = Vec::new();
+    let mut all_versions: HashSet<&Version> = HashSet::new();
+    all_versions.extend(old_counts.keys());
+    all_versions.extend(new_counts.keys());
+    #[expect(clippy::iter_over_hash_type)]
+    for version in &all_versions {
+      let old = old_counts.get(*version).copied().unwrap_or(0);
+      let new = new_counts.get(*version).copied().unwrap_or(0);
+      common_count += old.min(new);
+      for _ in 0..old.saturating_sub(new) {
+        unique_old.push((*version).clone());
+      }
+      for _ in 0..new.saturating_sub(old) {
+        unique_new.push((*version).clone());
+      }
+    }
 
     let status = if unique_old.is_empty() && unique_new.is_empty() {
       continue;
@@ -1522,8 +1531,12 @@ mod tests {
     );
     let result = generate_diffs_from_paths(paths);
     assert_eq!(result.len(), 1);
-    // Should detect the upgrade from 1.0.0 to 2.0.0
-    assert_eq!(result[0].status, DiffStatus::Changed(Change::Upgraded));
+    // Three 1.0.0s gone, one 2.0.0 added: one slot pairs as an upgrade,
+    // the two unmatched 1.0.0 removals register as downgrades.
+    assert_eq!(
+      result[0].status,
+      DiffStatus::Changed(Change::UpgradeDowngrade),
+    );
   }
 
   #[test]
@@ -1689,5 +1702,53 @@ mod tests {
     // 1.0.0 removed, 1.2.0 and 3.0.0 added
     assert_eq!(result[0].old.len(), 1);
     assert_eq!(result[0].new.len(), 2);
+  }
+
+  #[test]
+  fn generate_diffs_duplicate_added() {
+    // Old: one v1.0.0. New: two v1.0.0 (e.g. overlay variant alongside
+    // upstream). The added copy is a real change and must surface.
+    let mut paths = HashMap::new();
+    paths.insert(
+      "pkg".to_owned(),
+      (vec![Version::new("1.0.0")], vec![
+        Version::new("1.0.0"),
+        Version::new("1.0.0"),
+      ]),
+    );
+    let result = generate_diffs_from_paths(paths);
+    assert_eq!(result.len(), 1);
+  }
+
+  #[test]
+  fn generate_diffs_duplicate_removed() {
+    // Old: two v1.0.0. New: one v1.0.0. The dropped copy must surface.
+    let mut paths = HashMap::new();
+    paths.insert(
+      "pkg".to_owned(),
+      (vec![Version::new("1.0.0"), Version::new("1.0.0")], vec![
+        Version::new("1.0.0"),
+      ]),
+    );
+    let result = generate_diffs_from_paths(paths);
+    assert_eq!(result.len(), 1);
+  }
+
+  #[test]
+  fn generate_diffs_duplicate_alongside_existing_versions() {
+    // Closure had {v1, v2}, now has {v1, v2, v2} because a locally
+    // pinned derivation shadows upstream v2. The new duplicate must
+    // surface even though both sides have the same version *set*.
+    let mut paths = HashMap::new();
+    paths.insert(
+      "pkg".to_owned(),
+      (vec![Version::new("1.0.0"), Version::new("2.0.0")], vec![
+        Version::new("1.0.0"),
+        Version::new("2.0.0"),
+        Version::new("2.0.0"),
+      ]),
+    );
+    let result = generate_diffs_from_paths(paths);
+    assert_eq!(result.len(), 1);
   }
 }


### PR DESCRIPTION
Fixes #60.

`generate_diffs_from_paths` built `HashMap<Version, usize>` counts via
`count_versions`, then immediately discarded the counts by collecting
just the keys into a `HashSet`. From there, `unique_old` / `unique_new`
were computed as set differences, so `{v ×1}` vs `{v ×2}` flattened to
`{v}` vs `{v}` and the entry hit the `continue` branch — making the
package disappear from the diff even though the closure genuinely
gained (or lost) a copy.

In practice this triggers when an overlay derivation produces the
same `(pname, version)` as an existing one in the closure — e.g. a
locally pinned package shadowing upstream. The `SIZE`/`DIFF` lines
(which come from the closure walk, not the deduped name set) still
update correctly, so the report shows a size delta with no
corresponding package row.

## Fix

Replace the `HashSet`-based diff with multiplicity-aware accounting
over the union of versions. For each `Version` seen in either map,
`common_count` accumulates `min(old, new)` and the surplus on each
side goes into `unique_old` / `unique_new`. The downstream
classification branches (`Added` / `Removed` / `Changed`) keep
working unchanged.

## Tests

Three new tests cover the regression:

- `generate_diffs_duplicate_added` — `(old=[v], new=[v, v])` must
  produce a diff entry.
- `generate_diffs_duplicate_removed` — `(old=[v, v], new=[v])` must
  produce a diff entry.
- `generate_diffs_duplicate_alongside_existing_versions` —
  `(old=[v1, v2], new=[v1, v2, v2])`, the real-world reproducer.

All three fail on `main` (`result.len() == 0`) and pass after the fix.

One existing test changes its expected status:
`generate_diffs_version_deduplication`, input
`(old=[1.0.0 ×3], new=[2.0.0])`. It previously asserted
`Changed(Upgraded)` because the set-flatten reduced the input to
`[1.0.0]` vs `[2.0.0]` before the matcher saw it — only the clean
upgrade was visible to `determine_change_status`. With counts
preserved, the Hungarian matcher pairs one `1.0.0` with `2.0.0`
(upgrade) and the two unmatched `1.0.0`s register as downgrades,
so the entry is now `Changed(UpgradeDowngrade)` — i.e. what
actually happens to the closure. The test wasn't *wrong* before;
its input was lossy by the time it reached the classifier.

## Verification

```
$ nix develop -c cargo test
test result: ok. 94 passed; 0 failed; ...
$ nix develop -c cargo fmt --check
(clean)
```

`cargo clippy` was run too; no new lints in the touched code
(existing warnings in `src/version.rs` etc. are untouched).

## Disclosure

This PR (and the linked issue) were drafted with Claude Opus 4.7
acting as a writing / implementation assistant. The bug was real
(hit on my own NixOS system); the analysis, fix design, and tests
were derived from reading `src/diff.rs` at 1.4.2 and verifying the
failure mode with `cargo test` before applying the change.
