### PR TITLE
change size diff colors

### DIFF
--- a/crates/dix/src/render.rs
+++ b/crates/dix/src/render.rs
@@ -1,4 +1,5 @@
 use std::{
+  cmp::Ordering,
   fmt::{
     self,
     Write as _,
@@ -140,10 +141,10 @@ fn write_size_diff(
     writer,
     "{header}: {size_diff}",
     header = "DIFF".bold(),
-    size_diff = if size_diff.bytes() > 0 {
-      size_diff.green()
-    } else {
-      size_diff.red()
+    size_diff = match size_diff.bytes().cmp(&0) {
+      Ordering::Less => size_diff.green(),
+      Ordering::Equal => size_diff.resetting(),
+      Ordering::Greater => size_diff.red(),
     },
   )
 }


### PR DESCRIPTION
I'd argue that 0 bytes size diff shouldn't be red. Or green. So this PR changes it from red to uncolored.

I'd also argue that the less disk space a thing takes up, the better. So it's "-" size diff that is good (and therefore green) and "+" that is bad (and therefore red). So this PR swaps the current colors.
