### PR TITLE
dix: change diffing model to snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,32 @@ This is a changelog of the `dix` repository. It follows the
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format and adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.2
+
+### Added
+
+- Added `StoreSnapshot`, `query_store_snapshot(...)`,
+  `query_store_snapshot_with_backend(...)`, and `diff_store_snapshots(...)`
+  for users who want to capture store data separately from report generation.
+  This lets callers provide snapshots from custom sources, including remote
+  machines or persisted snapshot files.
+- Added `CommandBackend::store_url(...)` for callers that want command-backed
+  queries to target a specific Nix store URI.
+
+### Changed
+
+- Changed store-backed report generation to always query two in-memory store
+  snapshots before comparing them. The existing `query_diff_report(...)` API
+  continues to work, but now uses the same snapshot comparison path exposed to
+  crate users.
+
 ## 2.0.1
 
-## Added
+### Added
 
 - Added proper CI tests for all supported systems, formatting and checks.
 
-## Fixed
+### Fixed
 
 - Fixed build failures on aarch64-darwin and failing tests on x86_64-linux.
 

--- a/crates/dix/src/lib.rs
+++ b/crates/dix/src/lib.rs
@@ -30,10 +30,18 @@ pub use report::{
   PackageDiff,
   PackageSizeDelta,
   PathStats,
+  diff_store_snapshots,
   query_diff_report,
 };
 
+pub mod snapshot;
+pub use snapshot::{
+  StoreSnapshot,
+  query_store_snapshot,
+  query_store_snapshot_with_backend,
+};
 pub mod store;
+pub use store::CommandBackend;
 
 /// A validated store path. Always starts with `/nix/store`.
 ///

--- a/crates/dix/src/report.rs
+++ b/crates/dix/src/report.rs
@@ -12,10 +12,7 @@ use dix_diff::{
   PackageSnapshot,
   diff_snapshots,
 };
-use eyre::{
-  Result,
-  WrapErr as _,
-};
+use eyre::Result;
 use size::Size;
 
 use crate::{
@@ -23,9 +20,12 @@ use crate::{
   StorePath,
   Version,
   VersionDiff,
+  snapshot::{
+    StoreSnapshot,
+    query_store_snapshot_with_backend,
+  },
   store::{
     CombinedStoreBackend,
-    StoreBackend,
     StorePathInfo,
   },
 };
@@ -182,7 +182,7 @@ impl DiffReport {
     self.size_new
   }
 
-  #[cfg(test)]
+  #[cfg(all(test, feature = "json"))]
   pub(crate) const fn new_for_test(
     diffs: Vec<PackageDiff>,
     path_stats: PathStats,
@@ -191,26 +191,6 @@ impl DiffReport {
   ) -> Self {
     Self {
       diffs,
-      path_stats,
-      size_old,
-      size_new,
-    }
-  }
-
-  #[must_use]
-  fn from_queried_snapshots(snapshots: QueriedSnapshots) -> Self {
-    let QueriedSnapshots {
-      old,
-      new,
-      path_stats,
-      size_old,
-      size_new,
-    } = snapshots;
-    let old = old.into_snapshot_parts();
-    let new = new.into_snapshot_parts();
-
-    Self {
-      diffs: package_diffs_with_sizes(&old, &new),
       path_stats,
       size_old,
       size_new,
@@ -359,24 +339,15 @@ struct SnapshotPackages {
   package_sizes:  BTreeMap<String, Size>,
 }
 
-struct QueriedSnapshots {
-  old:        SnapshotPackages,
-  new:        SnapshotPackages,
-  path_stats: PathStats,
-  size_old:   Size,
-  size_new:   Size,
-}
-
 impl SnapshotPackages {
-  fn from_store_paths(
-    dependencies: impl IntoIterator<Item = StorePathInfo>,
-    selected: impl IntoIterator<Item = StorePath>,
+  fn from_store_snapshot(
+    snapshot: &StoreSnapshot,
     context: SnapshotContext,
   ) -> Self {
     let mut packages = Vec::new();
     let mut package_sizes = BTreeMap::<String, Size>::new();
 
-    for info in dependencies {
+    for info in &snapshot.closure {
       let Some(parsed) =
         parse_store_path_lossy(info.path(), context.dependencies)
       else {
@@ -393,9 +364,10 @@ impl SnapshotPackages {
 
     Self {
       packages,
-      selected_names: selected
-        .into_iter()
-        .filter_map(|path| parse_store_path_lossy(&path, context.selected))
+      selected_names: snapshot
+        .selected
+        .iter()
+        .filter_map(|path| parse_store_path_lossy(path, context.selected))
         .map(|parsed| parsed.name)
         .collect(),
       package_sizes,
@@ -445,11 +417,16 @@ pub fn query_diff_report(
     "starting diff report computation"
   );
 
-  let snapshots = CombinedStoreBackend::query_with_correctness(
+  let (old, new) = CombinedStoreBackend::query_with_correctness(
     force_correctness,
-    |backend| query_report_snapshots(backend, path_old, path_new),
+    |backend| {
+      Ok((
+        query_store_snapshot_with_backend(backend, path_old)?,
+        query_store_snapshot_with_backend(backend, path_new)?,
+      ))
+    },
   )?;
-  let report = DiffReport::from_queried_snapshots(snapshots);
+  let report = diff_store_snapshots(&old, &new);
   let path_stats = report.path_stats();
 
   tracing::info!(
@@ -466,74 +443,32 @@ pub fn query_diff_report(
   Ok(report)
 }
 
-fn query_report_snapshots(
-  backend: &impl StoreBackend,
-  path_old: &Path,
-  path_new: &Path,
-) -> Result<QueriedSnapshots> {
-  tracing::debug!("querying closure path info for old path");
-  let paths_old =
-    backend.query_closure_path_info(path_old).with_context(|| {
-      format!(
-        "failed to query closure path info of '{}'",
-        path_old.display()
-      )
-    })?;
+/// Builds a diff report from two already queried store snapshots.
+#[must_use]
+pub fn diff_store_snapshots(
+  old: &StoreSnapshot,
+  new: &StoreSnapshot,
+) -> DiffReport {
+  let path_stats = PathStats::between_path_info(&old.closure, &new.closure);
+  let size_old = total_nar_size(&old.closure);
+  let size_new = total_nar_size(&new.closure);
+  let old = SnapshotPackages::from_store_snapshot(old, SnapshotContext {
+    dependencies: "old dependency",
+    selected:     "old system",
+  })
+  .into_snapshot_parts();
+  let new = SnapshotPackages::from_store_snapshot(new, SnapshotContext {
+    dependencies: "new dependency",
+    selected:     "new system",
+  })
+  .into_snapshot_parts();
 
-  tracing::debug!("querying closure path info for new path");
-  let paths_new =
-    backend.query_closure_path_info(path_new).with_context(|| {
-      format!(
-        "failed to query closure path info of '{}'",
-        path_new.display()
-      )
-    })?;
-
-  tracing::debug!("querying system derivations for old path");
-  let system_derivations_old = backend
-    .query_system_derivations(path_old)
-    .with_context(|| {
-      format!(
-        "failed to query system derivations of '{}'",
-        path_old.display()
-      )
-    })?;
-
-  tracing::debug!("querying system derivations for new path");
-  let system_derivations_new = backend
-    .query_system_derivations(path_new)
-    .with_context(|| {
-      format!(
-        "failed to query system derivations of '{}'",
-        path_new.display()
-      )
-    })?;
-
-  let path_stats = PathStats::between_path_info(&paths_old, &paths_new);
-  let size_old = total_nar_size(&paths_old);
-  let size_new = total_nar_size(&paths_new);
-
-  Ok(QueriedSnapshots {
-    old: SnapshotPackages::from_store_paths(
-      paths_old,
-      system_derivations_old,
-      SnapshotContext {
-        dependencies: "old dependency",
-        selected:     "old system",
-      },
-    ),
-    new: SnapshotPackages::from_store_paths(
-      paths_new,
-      system_derivations_new,
-      SnapshotContext {
-        dependencies: "new dependency",
-        selected:     "new system",
-      },
-    ),
+  DiffReport {
+    diffs: package_diffs_with_sizes(&old, &new),
     path_stats,
     size_old,
     size_new,
-  })
+  }
 }
 
 fn parse_store_path_lossy(
@@ -608,32 +543,15 @@ mod tests {
       store_path_info(&format!("helix-tree-sitter-pod-{old_hash}"), 100);
     let new_info =
       store_path_info(&format!("helix-tree-sitter-pod-{new_hash}"), 200);
-    let path_stats = PathStats::between(
-      std::slice::from_ref(old_info.path()),
-      std::slice::from_ref(new_info.path()),
-    );
-
-    let report = DiffReport::from_queried_snapshots(QueriedSnapshots {
-      old: SnapshotPackages::from_store_paths(
-        [old_info],
-        std::iter::empty(),
-        SnapshotContext {
-          dependencies: "old dependency",
-          selected:     "old selected",
-        },
-      ),
-      new: SnapshotPackages::from_store_paths(
-        [new_info],
-        std::iter::empty(),
-        SnapshotContext {
-          dependencies: "new dependency",
-          selected:     "new selected",
-        },
-      ),
-      path_stats,
-      size_old: Size::from_bytes(100),
-      size_new: Size::from_bytes(200),
-    });
+    let old_snapshot = StoreSnapshot {
+      closure:  vec![old_info],
+      selected: Vec::new(),
+    };
+    let new_snapshot = StoreSnapshot {
+      closure:  vec![new_info],
+      selected: Vec::new(),
+    };
+    let report = diff_store_snapshots(&old_snapshot, &new_snapshot);
 
     assert_eq!(report.diffs.len(), 1);
     let diff = &report.diffs[0];
@@ -663,32 +581,15 @@ mod tests {
       "source",
       9_000,
     );
-    let path_stats = PathStats::between(
-      std::slice::from_ref(old_info.path()),
-      std::slice::from_ref(new_info.path()),
-    );
-
-    let report = DiffReport::from_queried_snapshots(QueriedSnapshots {
-      old: SnapshotPackages::from_store_paths(
-        [old_info],
-        std::iter::empty(),
-        SnapshotContext {
-          dependencies: "old dependency",
-          selected:     "old selected",
-        },
-      ),
-      new: SnapshotPackages::from_store_paths(
-        [new_info],
-        std::iter::empty(),
-        SnapshotContext {
-          dependencies: "new dependency",
-          selected:     "new selected",
-        },
-      ),
-      path_stats,
-      size_old: Size::from_bytes(100),
-      size_new: Size::from_bytes(9_000),
-    });
+    let old_snapshot = StoreSnapshot {
+      closure:  vec![old_info],
+      selected: Vec::new(),
+    };
+    let new_snapshot = StoreSnapshot {
+      closure:  vec![new_info],
+      selected: Vec::new(),
+    };
+    let report = diff_store_snapshots(&old_snapshot, &new_snapshot);
 
     assert_eq!(report.diffs.len(), 1);
     let diff = &report.diffs[0];
@@ -697,5 +598,26 @@ mod tests {
     assert!(diff.versions.is_empty());
     assert_eq!(diff.size.old_size(), Size::from_bytes(100));
     assert_eq!(diff.size.new_size(), Size::from_bytes(9_000));
+  }
+
+  #[test]
+  fn diff_store_snapshots_preserves_selection_status() {
+    let old_info = store_path_info("package-1.0", 100);
+    let new_info = store_path_info("package-2.0", 200);
+    let old_snapshot = StoreSnapshot {
+      closure:  vec![old_info.clone()],
+      selected: vec![old_info.path().clone()],
+    };
+    let new_snapshot = StoreSnapshot {
+      closure:  vec![new_info],
+      selected: Vec::new(),
+    };
+    let report = diff_store_snapshots(&old_snapshot, &new_snapshot);
+
+    assert_eq!(report.diffs.len(), 1);
+    assert_eq!(
+      report.diffs[0].selection,
+      DerivationSelectionStatus::NewlyUnselected,
+    );
   }
 }

--- a/crates/dix/src/snapshot.rs
+++ b/crates/dix/src/snapshot.rs
@@ -1,0 +1,60 @@
+use std::path::Path;
+
+use eyre::{
+  Context as _,
+  Result,
+};
+
+use crate::{
+  StorePath,
+  store::{
+    CombinedStoreBackend,
+    StoreBackend,
+    StorePathInfo,
+  },
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoreSnapshot {
+  pub closure:  Vec<StorePathInfo>,
+  pub selected: Vec<StorePath>,
+}
+
+/// Queries Nix store data for one path and returns a reusable snapshot.
+///
+/// # Errors
+///
+/// Returns an error if the store connection or path queries fail.
+pub fn query_store_snapshot(
+  path: &Path,
+  force_correctness: bool,
+) -> Result<StoreSnapshot> {
+  CombinedStoreBackend::query_with_correctness(force_correctness, |backend| {
+    query_store_snapshot_with_backend(backend, path)
+  })
+}
+
+/// Queries Nix store data for one path using a caller-provided backend.
+///
+/// This does not call [`StoreBackend::connect`] or [`StoreBackend::close`].
+/// Callers using connection-backed implementations must manage that lifecycle.
+///
+/// # Errors
+///
+/// Returns an error if the backend cannot query the path.
+pub fn query_store_snapshot_with_backend(
+  backend: &dyn StoreBackend,
+  path: &Path,
+) -> Result<StoreSnapshot> {
+  tracing::debug!(path = %path.display(), "querying closure path info");
+  let closure = backend.query_closure_path_info(path).with_context(|| {
+    format!("failed to query closure path info of '{}'", path.display())
+  })?;
+
+  tracing::debug!(path = %path.display(), "querying system derivations");
+  let selected = backend.query_system_derivations(path).with_context(|| {
+    format!("failed to query system derivations of '{}'", path.display())
+  })?;
+
+  Ok(StoreSnapshot { closure, selected })
+}

--- a/crates/dix/src/store/nix_command.rs
+++ b/crates/dix/src/store/nix_command.rs
@@ -29,29 +29,33 @@ use crate::{
   },
 };
 
-#[derive(Debug)]
 /// Uses nix commands to perform queries.
 ///
 /// This is similar in implementation to the old `dix` in its early stages and
 /// is supposed to be a final fallback if the direct queries on the database
-/// fail. It is considerably slower than the direct queries and currently does
-/// not support querying the whole dependency graph.
+/// fail. It is considerably slower than the direct queries.
 ///
 /// The internal command use is configurable but is expected to be a drop-in
 /// replacement for the nix-store command.
+#[derive(Debug)]
 pub struct CommandBackend {
   nix_store_cmd: String,
   nix_cmd:       String,
+  store_url:     Option<String>,
 }
 
 impl Display for CommandBackend {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     write!(
       f,
-      "CommandBackend(nix='{cmd}', nix-store='{store}')",
+      "CommandBackend(nix='{cmd}', nix-store='{store}'",
       cmd = self.nix_cmd,
-      store = self.nix_store_cmd
-    )
+      store = self.nix_store_cmd,
+    )?;
+    if let Some(store_url) = &self.store_url {
+      write!(f, ", store='{store_url}'")?;
+    }
+    write!(f, ")")
   }
 }
 
@@ -60,6 +64,7 @@ impl Default for CommandBackend {
     Self {
       nix_store_cmd: "nix-store".to_owned(),
       nix_cmd:       "nix".to_owned(),
+      store_url:     None,
     }
   }
 }
@@ -70,7 +75,32 @@ impl CommandBackend {
     Self {
       nix_store_cmd: cmd_nix_store,
       nix_cmd:       cmd_nix,
+      store_url:     None,
     }
+  }
+
+  /// Use a specific Nix store URI for command-backed queries.
+  #[must_use]
+  pub fn store_url(mut self, store_url: impl Into<String>) -> Self {
+    self.store_url = Some(store_url.into());
+    self
+  }
+
+  fn nix_store_command(&self) -> Command {
+    let mut command = Command::new(&self.nix_store_cmd);
+    if let Some(store_url) = &self.store_url {
+      command.arg("--store").arg(store_url);
+    }
+    command
+  }
+
+  fn nix_command(&self, subcommand: &str) -> Command {
+    let mut command = Command::new(&self.nix_cmd);
+    command.arg(subcommand);
+    if let Some(store_url) = &self.store_url {
+      command.arg("--store").arg(store_url);
+    }
+    command
   }
 }
 
@@ -126,7 +156,8 @@ impl StoreBackend for CommandBackend {
   }
 
   fn query_system_derivations(&self, system: &Path) -> Result<Vec<StorePath>> {
-    let output = Command::new(&self.nix_store_cmd)
+    let output = self
+      .nix_store_command()
       .args(["--query", "--references"])
       .arg(system.join("sw"))
       .output()
@@ -144,7 +175,8 @@ impl StoreBackend for CommandBackend {
   }
 
   fn query_dependents(&self, path: &Path) -> Result<Vec<StorePath>> {
-    let output = Command::new(&self.nix_store_cmd)
+    let output = self
+      .nix_store_command()
       .args(["--query", "--requisites"])
       .arg(path)
       .output()
@@ -162,8 +194,9 @@ impl StoreBackend for CommandBackend {
   }
 
   fn query_closure_path_info(&self, path: &Path) -> Result<Vec<StorePathInfo>> {
-    let output = Command::new(&self.nix_cmd)
-      .args(["path-info", "--recursive", "--size"])
+    let output = self
+      .nix_command("path-info")
+      .args(["--recursive", "--size"])
       .arg(path)
       .output()
       .wrap_err("Encountered error while executing nix command")?;
@@ -206,6 +239,21 @@ mod tests {
       .map(|(index, path)| format!("{path} {}", index + 1))
       .collect::<Vec<String>>()
       .join("\n")
+  }
+
+  fn command_args(command: &Command) -> Vec<String> {
+    command
+      .get_args()
+      .map(|arg| arg.to_string_lossy().into_owned())
+      .collect()
+  }
+
+  #[test]
+  fn store_url_is_added_to_nix_store_commands() {
+    let backend = CommandBackend::default().store_url("ssh://builder");
+    let command = backend.nix_store_command();
+
+    assert_eq!(command_args(&command), vec!["--store", "ssh://builder"]);
   }
 
   #[test]


### PR DESCRIPTION
Changes to a snapshot-based diffing model. This allows us to create and diff individual snapshots, which can be used to do e.g. diffing of remote store paths. 